### PR TITLE
EXT SDA/SCL as GPIO pins

### DIFF
--- a/src/FabiWare.h
+++ b/src/FabiWare.h
@@ -74,7 +74,7 @@
 //#define DEBUG_OUTPUT_SENSORS 	 // enable sensors.cpp debugging, showing whats happening on sensor reading & init
 //#define DEBUG_DELAY_STARTUP 	 // enable a 3s delay after Serial.begin and before all the other stuff.
 #define DEBUG_ACTIVITY_LED 	   // enable blinking internal led signaling activity (in sensor loop, core1).
-#define DEBUG_SLEEP_WITH_USB true  /* if true, we will send the Pico to sleep even with USB connected */
+#define DEBUG_SLEEP_WITH_USB false  /* if true, we will send the Pico to sleep even with USB connected */
 //#define DEBUG_PRESSURE_RAWVALUES // raw output of pressure values and filtered output
 //#define DEBUG_MPRLS_ERRORFLAGS // continously print error flags of MPRLS
 //#define DEBUG_BATTERY_MANAGEMENT 	 // enable a debug output for battery state detection and management.

--- a/src/FabiWare.h
+++ b/src/FabiWare.h
@@ -188,6 +188,7 @@ struct SensorData {
 extern alarm_pool_t *app_alarm_pool;
 extern char moduleName[];
 extern uint8_t actSlot;
+extern bool useI2CasGPIO;
 extern uint8_t goingToSleep;
 extern uint8_t addonUpgrade;
 extern struct GlobalSettings globalSettings;

--- a/src/FabiWare.h
+++ b/src/FabiWare.h
@@ -74,6 +74,7 @@
 //#define DEBUG_OUTPUT_SENSORS 	 // enable sensors.cpp debugging, showing whats happening on sensor reading & init
 //#define DEBUG_DELAY_STARTUP 	 // enable a 3s delay after Serial.begin and before all the other stuff.
 #define DEBUG_ACTIVITY_LED 	   // enable blinking internal led signaling activity (in sensor loop, core1).
+#define DEBUG_SLEEP_WITH_USB true  /* if true, we will send the Pico to sleep even with USB connected */
 //#define DEBUG_PRESSURE_RAWVALUES // raw output of pressure values and filtered output
 //#define DEBUG_MPRLS_ERRORFLAGS // continously print error flags of MPRLS
 //#define DEBUG_BATTERY_MANAGEMENT 	 // enable a debug output for battery state detection and management.
@@ -246,6 +247,9 @@ typedef char* uint_farptr_t_FM;
 #endif
 #ifdef DEBUG_MPRLS_ERRORFLAGS
   #warning "DEBUG_MPRLS_ERRORFLAGS is defined, do not release this way!"
+#endif
+#if DEBUG_SLEEP_WITH_USB == true
+  #warning "DEBUG_SLEEP_WITH_USB is true, don't release!"
 #endif
 
 #endif

--- a/src/buttons.cpp
+++ b/src/buttons.cpp
@@ -129,12 +129,19 @@ void initButtons() {
 
 void handlePress (int buttonIndex)   // a button was pressed
 {
+  #ifdef DEBUG_OUTPUT_FULL
+    Serial.print("P: "); Serial.println(buttonIndex);
+    Serial.print(buttons[buttonIndex].mode); Serial.print(" "); Serial.print(buttons[buttonIndex].value); Serial.print(" "); Serial.println(buttonKeystrings[buttonIndex]);
+  #endif
   buttonStates |= (1<<buttonIndex); //save for reporting
   performCommand(buttons[buttonIndex].mode, buttons[buttonIndex].value, buttonKeystrings[buttonIndex], 1);
 }
 
 void handleRelease (int buttonIndex)    // a button was released: deal with "sticky"-functions
 {
+  #ifdef DEBUG_OUTPUT_FULL
+    Serial.print("R: "); Serial.println(buttonIndex);
+  #endif
   buttonStates &= ~(1<<buttonIndex); //save for reporting
   switch (buttons[buttonIndex].mode) {
     // release mouse actions

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -339,7 +339,7 @@ void performCommand (uint8_t cmd, int16_t par1, char * keystring, int8_t periodi
 #ifdef DEBUG_OUTPUT_FULL
       if (slotSettings.stickMode == STICKMODE_MOUSE)
         Serial.println("mouse function activated");
-      else if (slotSettings.stickMode >= STICKMODE_JOYSTICK_XY)
+      else if (slotSettings.stickMode >= STICKMODE_JOYSTICK_1)
         Serial.println("joystick function activated");
       else Serial.println("alternative functions activated");
 #endif

--- a/src/gpio.h
+++ b/src/gpio.h
@@ -73,7 +73,7 @@ extern int8_t  input_map[NUMBER_OF_PHYSICAL_BUTTONS];  // maps the button number
 
 #ifdef RP2350
   #define NUMBER_OF_WAKEUP_PINS 9           // number of pins that can wake up FABI from sleep
-  #define WAKEUP_PIN_MAP {11,9,8,4,3,26,27,-1,-1}
+  #define WAKEUP_PIN_MAP {11,9,8,4,3,26,27,18,19}
    extern int8_t  wakeup_pin_map[NUMBER_OF_WAKEUP_PINS];  // maps the wakeup pin number to physical pin
 #endif
 

--- a/src/gpio.h
+++ b/src/gpio.h
@@ -72,8 +72,8 @@
 extern int8_t  input_map[NUMBER_OF_PHYSICAL_BUTTONS];  // maps the button number to physical pin
 
 #ifdef RP2350
-  #define NUMBER_OF_WAKEUP_PINS 7           // number of pins that can wake up FABI from sleep
-  #define WAKEUP_PIN_MAP {11,9,8,4,3,26,27}
+  #define NUMBER_OF_WAKEUP_PINS 9           // number of pins that can wake up FABI from sleep
+  #define WAKEUP_PIN_MAP {11,9,8,4,3,26,27,-1,-1}
    extern int8_t  wakeup_pin_map[NUMBER_OF_WAKEUP_PINS];  // maps the wakeup pin number to physical pin
 #endif
 

--- a/src/lpwFuncs.cpp
+++ b/src/lpwFuncs.cpp
@@ -147,7 +147,8 @@ void performBatteryManagement()  {
   #endif
 
   // check user inactivity, possibly initiate power save mode
-  if (!sensorData.usbConnected) {
+
+  if (!sensorData.usbConnected || DEBUG_SLEEP_WITH_USB) {
     inactivityTime += BATTERY_UPDATE_INTERVAL;
     if (inactivityTime >= (inactivityTimeMinutes*60000 + inactivityTimeSeconds*1000))
       inactivityHandler();  // time to go to sleep...
@@ -244,7 +245,8 @@ void configureGPIOForSleep() {
  */
 void dormantUntilInterrupt(int8_t *wake_interrupt_gpios, int8_t amt_gpios) {
   sleep_run_from_lposc(); // use low-power oscillator for minimal power consumption
-  sleep_goto_dormant_until_edge_high(wake_interrupt_gpios, amt_gpios); // wait for rising edge interrupt
+  sleep_goto_dormant_until_pin(wake_interrupt_gpios, amt_gpios, true, false);
+  //sleep_goto_dormant_until_edge_high(wake_interrupt_gpios, amt_gpios); // wait for rising edge interrupt
   sleep_power_up(); // restore sys clocks after waking up (using rosc -> jump starts processor)
   delay(100); // allow some time for system to stabilize after restoring sys clocks
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -335,9 +335,6 @@ void setup1() {
     Wire1.end();
     pinMode(PIN_WIRE1_SDA_,INPUT_PULLUP);
     pinMode(PIN_WIRE1_SCL_,INPUT_PULLUP);
-    //add SDA/SCL as wakeup pins
-    wakeup_pin_map[NUMBER_OF_WAKEUP_PINS-2] =  PIN_WIRE1_SDA_;
-    wakeup_pin_map[NUMBER_OF_WAKEUP_PINS-1] =  PIN_WIRE1_SCL_;
   }
   #endif
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -114,6 +114,7 @@ struct SensorData sensorData {
 struct SlotSettings slotSettings;             // contains all slot settings
 uint8_t workingmem[WORKINGMEM_SIZE];          // working memory (command parser, IR-rec/play)
 uint8_t actSlot = 0;                          // number of current slot
+bool useI2CasGPIO = false;                     // if set, we will use the SDA/SCL lines of Wire1 as GPIOs, set when INTERNAL_ADC is used and no I2C devices detected on startup.
 uint8_t goingToSleep = 0;                    // flag to indicate that the device is going to sleep mode
 
 /*
@@ -121,7 +122,7 @@ uint8_t goingToSleep = 0;                    // flag to indicate that the device
  */
 uint8_t devicesWire[8] = {0};                 // active I2C devices on Wire, see supported_devices[]
 uint8_t devicesWire1[8] = {0};                 // active I2C devices on Wire1, see supported_devices[]
-void testI2Cdevices(TwoWire *interface, uint8_t *device_list);
+int testI2Cdevices(TwoWire *interface, uint8_t *device_list);
 
 /**
    @name setup
@@ -300,6 +301,8 @@ void loop() {
 void setup1() {
   delay(250);  // some time to let core0 initialize
 
+  int i2cDevices = 0;
+
   #ifdef DEBUG_ACTIVITY_LED
     pinMode(LED_BUILTIN,OUTPUT);
     digitalWrite(LED_BUILTIN,HIGH); // LED on to indicate core1 is running
@@ -314,7 +317,7 @@ void setup1() {
   Wire1.setClock(400000);  // use 400kHz I2C clock
 
   //check the I2C bus for active devices, add to array
-  testI2Cdevices(&Wire1,devicesWire1);
+  i2cDevices = testI2Cdevices(&Wire1,devicesWire1);
 
   #ifdef DEBUG_DELAY_STARTUP
     delay(3000);  // allow some time for serial interface to come up
@@ -323,6 +326,20 @@ void setup1() {
   initSensors();
   if (getForceSensorType()==FORCE_NAU7802)
     setSensorBoard(slotSettings.sb); // apply sensorboard settings
+
+  #ifndef FLIPMOUSE
+  //using external joystick via INTERNAL_ADC and no I2C devices: use pins as GPIO.
+  if(getForceSensorType() == FORCE_INTERNAL_ADC  && i2cDevices == 0) {
+    useI2CasGPIO = true;
+    //Serial.println("I2C->GPIO");
+    Wire1.end();
+    pinMode(PIN_WIRE1_SDA_,INPUT_PULLUP);
+    pinMode(PIN_WIRE1_SCL_,INPUT_PULLUP);
+    //add SDA/SCL as wakeup pins
+    wakeup_pin_map[NUMBER_OF_WAKEUP_PINS-2] =  PIN_WIRE1_SDA_;
+    wakeup_pin_map[NUMBER_OF_WAKEUP_PINS-1] =  PIN_WIRE1_SCL_;
+  }
+  #endif
 
   // initBlink(10,20);  // first signs of life!
 }
@@ -365,28 +382,33 @@ void loop1() {
   #endif
 
   // every 1s: check for changed I2C devices. TBD: for FABI only?
+  #ifndef FLIPMOUSE
   NB_DELAY_START(i2cscan, 1000)
-    //create a copy of list before checking again
-    uint8_t olddevices[8];
-    memcpy(olddevices, devicesWire1, 8);
-    //check again
-    testI2Cdevices(&Wire1, devicesWire1);
-    //check if they match, if not -> restart
-    if (memcmp(olddevices, devicesWire1, 8) != 0)
-    {
-      Serial.println("Devices on Wire1 changed -> restarting!");
-      watchdog_reboot(0, 0, 10);
-      while (1)
+    //check only if we are NOT using SDA/SCL as GPIOs...
+    if(!useI2CasGPIO) {
+      //create a copy of list before checking again
+      uint8_t olddevices[8];
+      memcpy(olddevices, devicesWire1, 8);
+      //check again
+      testI2Cdevices(&Wire1, devicesWire1);
+      //check if they match, if not -> restart
+      if (memcmp(olddevices, devicesWire1, 8) != 0)
       {
-        continue;
+        Serial.println("Devices on Wire1 changed -> restarting!");
+        watchdog_reboot(0, 0, 10);
+        while (1)
+        {
+          continue;
+        }
       }
     }
   NB_DELAY_END
+  #endif
 
   delay(1); // core1: sleep a bit ...  
 }
 
-void testI2Cdevices(TwoWire *interface, uint8_t *device_list) {
+int testI2Cdevices(TwoWire *interface, uint8_t *device_list) {
   int devicenr = 0;     //currently used I2C address index of supported_devices[]
   int devicecount = 0;  //count of found devices, used as offset in active devices (devicesWire[])
 
@@ -406,4 +428,6 @@ void testI2Cdevices(TwoWire *interface, uint8_t *device_list) {
     //next address to be tested
     devicenr++;
   }
+
+  return devicecount;
 }

--- a/src/modes.cpp
+++ b/src/modes.cpp
@@ -43,6 +43,14 @@ void handleUserInteraction()
   for (int i = 0; i < NUMBER_OF_PHYSICAL_BUTTONS; i++) // update button press / release events
   handleButton(i, digitalRead(input_map[i]) == LOW ? 1 : 0);
 
+  #ifndef FLIPMOUSE
+  // SDA&SCL as GPIOs
+  if(useI2CasGPIO) {
+    handleButton(SIP_BUTTON, digitalRead(PIN_WIRE1_SDA_) == LOW ? 1 : 0);
+    handleButton(PUFF_BUTTON, digitalRead(PIN_WIRE1_SCL_) == LOW ? 1 : 0);
+  }
+  #endif
+
   #ifdef FLIPMOUSE
     // check "long-press" of internal button unpairing all BT hosts
     if (digitalRead(input_map[0]) == LOW) {

--- a/src/reporting.cpp
+++ b/src/reporting.cpp
@@ -129,14 +129,16 @@ void reportValues()
   if (!reportRawValues)   return;
 
   // update / override sip and puff button states for reporting
-  if (sensorData.pressure < slotSettings.ts) buttonStates |= (1<<SIP_BUTTON);
-  else buttonStates &= ~(1<<SIP_BUTTON);
-  if (sensorData.pressure < slotSettings.ss) buttonStates |= (1<<STRONGSIP_BUTTON);
-  else buttonStates &= ~(1<<STRONGSIP_BUTTON);
-  if (sensorData.pressure > slotSettings.tp) buttonStates |= (1<<PUFF_BUTTON);
-  else buttonStates &= ~(1<<PUFF_BUTTON);
-  if (sensorData.pressure > slotSettings.sp) buttonStates |= (1<<STRONGPUFF_BUTTON);
-  else buttonStates &= ~(1<<STRONGPUFF_BUTTON);
+  if(getPressureSensorType() != PRESSURE_NONE) {
+    if (sensorData.pressure < slotSettings.ts) buttonStates |= (1<<SIP_BUTTON);
+    else buttonStates &= ~(1<<SIP_BUTTON);
+    if (sensorData.pressure < slotSettings.ss) buttonStates |= (1<<STRONGSIP_BUTTON);
+    else buttonStates &= ~(1<<STRONGSIP_BUTTON);
+    if (sensorData.pressure > slotSettings.tp) buttonStates |= (1<<PUFF_BUTTON);
+    else buttonStates &= ~(1<<PUFF_BUTTON);  
+    if (sensorData.pressure > slotSettings.sp) buttonStates |= (1<<STRONGPUFF_BUTTON);
+    else buttonStates &= ~(1<<STRONGPUFF_BUTTON);
+  }
 
   if (valueReportCount++ > 50/UPDATE_INTERVAL) {      // report raw values approx. every 50ms !
     int32_t u=sensorData.yRaw+512; int32_t d=512-sensorData.yRaw;   // just for GUI compatibility with V2 (bar displays up/down)


### PR DESCRIPTION
This PR adds the possibility to re-use the SDA/SCL lines on the EXT header to be displayed and configured in the WebGUI.

Corresponding changes in the WebUI: https://github.com/asterics/Addon-Bluetooth-WebGUI/pull/20

Changes:
* added `useI2CasGPIO` flag
* the flag is set if an analog joystick (`FORCE_INTERNAL_ADC`) is used and no I2C devices on Wire1 (SDA/SCL in schematic) are detected
* if set, `SIP_BUTTON` and `PUFF_BUTTON` button mode are triggered with the former SDA/SCL lines
* in this setup it is impossible to use the I2C pressure sensor, so it doesn't interfere

To be fixed before merging:
* currently, the pins are not working as wake-up source